### PR TITLE
Replaced deprecated `distutils.version.LooseVersion`

### DIFF
--- a/modular-service-cli/CHANGELOG.md
+++ b/modular-service-cli/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update libraries:
   - `modular-cli-sdk` from 3.0.0 to 3.1.4
   - `click` from 7.1.2 to 8.3.0
+- Replaced deprecated `distutils.version.LooseVersion` with `packaging.version.Version` to support Python 3.12
 
 ## [3.2.1] - 2025-10-06
 - fix issue with the command `tenant settings put`

--- a/modular-service-cli/modular_service_cli/version.py
+++ b/modular-service-cli/modular_service_cli/version.py
@@ -1,26 +1,25 @@
 __version__ = '3.3.0'
 
 import sys
-from distutils.version import LooseVersion
-# TODO rewrite, distutils will be removed
+from packaging.version import Version
 
 
 def check_version_compatibility(api_version):
     if not api_version:
         print('Modular API did not return the version number!')
         return
-    cli_version = LooseVersion(__version__)
-    api_version = LooseVersion(api_version)
+    cli_version = Version(__version__)
+    api_version = Version(api_version)
     if cli_version > api_version:
-        print(f'Consider that you modularadmin version {cli_version} is '
+        print(f'Consider that your modularadmin version {cli_version} is '
               f'higher than the API version {api_version}')
         return
-    if cli_version.version[0] < api_version.version[0]:  # Major
+    if cli_version.major < api_version.major:  # Major
         print(f'CLI major version {cli_version} is lower than '
               f'the API version {api_version}. Please, update the CLI',
               file=sys.stderr)
         sys.exit(1)
-    if cli_version.version[1] < api_version.version[1]:  # Minor
+    if cli_version.minor < api_version.minor:  # Minor
         print(f'CLI Minor version {cli_version} is lower than the '
               f'API version {api_version}. Some features may not '
               f'work. Consider updating the CLI')


### PR DESCRIPTION
- Replaced deprecated `distutils.version.LooseVersion` with `packaging.version.Version` to support Python 3.12